### PR TITLE
Idea component dependency reordering

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,9 +5,16 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+      integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC"
+      crossorigin="anonymous"
+    />
+    <link
       href="https://fonts.googleapis.com/css?family=Work+Sans:400,700&display=swap"
       rel="stylesheet"
     />
+    <link href="./css/index.css" rel="stylesheet" />
     <title>Visualization - Final Project</title>
     <script src="https://d3js.org/d3.v7.min.js"></script>
     <link
@@ -22,6 +29,30 @@
       crossorigin=""
     ></script>
   </head>
-  <body></body>
+  <body>
+    <div class="content mb-1">
+      <div class="header h1">
+        Utah Avalanches
+      </div>
+    <div class="nav mb-3">
+      <ul class="nav nav-pills">
+        <li class="nav-item">
+          <a id="p1" class="nav-link active" aria-current="page" href="#">Page 1</a>
+        </li>
+        <li class="nav-item">
+          <a id="p2" class="nav-link" href="#">Page 2</a>
+        </li>
+        <li class="nav-item">
+          <a id="p3" class="nav-link" href="#">Page 3</a>
+        </li>
+      </ul>
+    </div>
+    </div>
+  </body>
   <script src="js/app.js" type="module"></script>
+  <script
+    src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM"
+    crossorigin="anonymous"
+  ></script>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -1,17 +1,38 @@
 import { Page1 } from "./page1/page1.js";
+import { Page2 } from "./page2/page2.js";
+import { Page3 } from "./page3/page3.js";
 import { loadData } from "./data.js";
 
 // Initialize each of pages 1, 2, and 3 with dataset
 const data = await loadData();
 
-const p1 = new Page1(data);
-p1.render();
+const pages = {
+  p1: new Page1(data),
+  p2: new Page2(data),
+  p3: new Page3(data),
+};
+
+pages.p1.render();
 
 var globalState = {
   data: data,
-  p1: p1,
+  pages: pages,
+  activePage: "p1",
 };
 
+const swapPage = (p) => {
+  if (globalState.activePage != p.target.id){
+    let oldPageId = globalState.activePage;
+    pages[globalState.activePage].hide();
+    pages[p.target.id].render();
+    globalState.activePage = p.target.id;
+
+    document.querySelector(`#${oldPageId}`).classList.remove('active')
+    p.target.classList.add('active')
+  }
+}
+
+d3.selectAll(".nav-link").on("click", swapPage);
 // store state globally for debugging
 window.globalState = globalState;
 

--- a/js/page1/main_map.js
+++ b/js/page1/main_map.js
@@ -1,13 +1,16 @@
 // main map component in P1
-var leaflet = await import("https://cdn.skypack.dev/leaflet");
-import("leaflet").catch((e) => {});
+import * as utils from "../shared/utils.js";
+
+// var leaflet = await import("https://cdn.skypack.dev/leaflet");
+// import("leaflet").catch((e) => {});
 
 if (L === undefined) L = leaflet;
 
 class MainMap {
-  constructor(div, data, verbose) {
+  constructor(data, verbose) {
     console.log("Init Main Map");
-    this.div = div;
+    this.dimensions = {};
+
     this.data = data;
     this.verbose = verbose === undefined ? false : verbose;
 
@@ -17,11 +20,13 @@ class MainMap {
       radius: 2.6,
       maxZoom: 12,
     };
+
+    this.mapId = "map";
   }
 
   /**
    * Converts coordinates of avalanches to geojson points
-   * @returns
+   * @returns {d3.GeoPermissibleObjects}
    */
   convert_points() {
     let avalanchePoints = {
@@ -52,7 +57,7 @@ class MainMap {
 
   /**
    * Initializes a leaflet map
-   * @param {('osm'|'terrain'})}
+   * @param {('osm'|'terrain1'|'terrain2'})}
    * @returns {L.Map}
    */
   init_map(provider) {
@@ -89,7 +94,7 @@ class MainMap {
         `"${provider}" is not a valid provider [${Object.keys(layerMap)}]`
       );
 
-    let map = L.map("map").setView(this.init.view, this.init.zoom);
+    let map = L.map(this.mapId).setView(this.init.view, this.init.zoom);
     let layer = layerMap[provider];
 
     layer.addTo(map);
@@ -117,7 +122,21 @@ class MainMap {
     return overlay.raise();
   }
 
-  render() {
+  /**
+   *
+   * @param {d3.Selection} div
+   */
+  render(div) {
+    this.div = div;
+    this.dimensions = utils.getDimensions(div);
+
+    console.log(this.dimensions)
+    this.mapDiv = div
+      .append("div")
+      .attr("id", this.mapId)
+      .style("width", `${this.dimensions.width}px`)
+      .style("height", `${this.dimensions.height}px`)
+
     let map = this.init_map("terrain1");
     let overlay = this.init_overlay(map);
 
@@ -129,13 +148,13 @@ class MainMap {
       const point = map.latLngToLayerPoint(new L.LatLng(y, x));
       return this.stream.point(point.x, point.y);
     };
-    
+
     // define a d3 projection
     const projectToMapD3 = d3.geoTransform({ point: projectToMap });
     const pathCreator = d3.geoPath().projection(projectToMapD3);
 
-    let incidentPoints = this.convert_points().features;
-    
+    let incidentPoints = this.convert_points();
+
     // let areas = d3.filter(
     //   this.data.map.features,
     //   (d) => d.geometry.type != "Point"
@@ -177,7 +196,7 @@ class MainMap {
 
     const incidentNodes = g
       .selectAll("circle")
-      .data(incidentPoints)
+      .data(incidentPoints.features)
       .join("circle")
       .attr("stroke", "black")
       .attr("stroke-width", 0.3)

--- a/js/page1/page1.js
+++ b/js/page1/page1.js
@@ -1,6 +1,7 @@
 import { MainMap } from "./main_map.js";
-import {TimeSelect} from "../shared/timeselect.js"
+import { TimeSelect } from "../shared/timeselect.js";
 import { ToolTip } from "./tooltip.js";
+import * as utils from "../shared/utils.js";
 
 // coordinate tooltip.js, main_map.js, timeselect.js
 
@@ -9,88 +10,90 @@ class Page1 {
     console.log("Init Page 1");
 
     this.data = data;
-    this.timeselect = new TimeSelect(data);
-    this.tooltip = new ToolTip(data);
-    
+
+    this.padding = 10;
+
+    this.dimensions = {
+      timeselect: {
+        width: 1000,
+        height: 100,
+      },
+      map: {
+        width: 700,
+        height: 700,
+      },
+      tooltip: {
+        width: 600,
+        height: 600,
+      },
+    };
+
+    this.positions = {
+      timeselect: {
+        x: 0,
+        y: 0,
+      },
+      map: {
+        x: 0,
+        y: this.dimensions.timeselect.height + this.padding,
+      },
+      tooltip: {
+        x: 0,
+        y:
+          this.dimensions.timeselect.height +
+          this.dimensions.map.height +
+          this.padding,
+      },
+    };
+
+    // initialize components
+    this.timeselect = new TimeSelect(this.data);
+    this.tooltip = new ToolTip(this.data);
+    this.map = new MainMap(this.data);
   }
 
   render() {
-    let mapDiv = d3
-      .select("body")
+    let div = d3.select(".content");
+
+    let tsDiv = div
       .append("div")
-      .attr("id", "map")
-      .style("height", "700px")
-      .style("width", "700px");
+      .attr("id", "timeselect")
+      .style("width", `${this.dimensions.timeselect.width}px`)
+      .style("height", `${this.dimensions.timeselect.height}px`)
+      .style("left", `${this.positions.timeselect.x}px`)
+      .style("top", `${this.positions.timeselect.y}px`)
+      .classed('my-2', true)
 
-    this.map = new MainMap(mapDiv, this.data);
+    // .style("position", "absolute");
 
-    this.map.render();
+    let mapDiv = div
+      .append("div")
+      .attr("id", "map-container")
+      .style("width", `${this.dimensions.map.width}px`)
+      .style("height", `${this.dimensions.map.height}px`)
+      .style("left", `${this.positions.map.x}px`)
+      .style("top", `${this.positions.map.y}px`)
+      .classed('mb-5', true)
+      // .style("position", "absolute");
 
-    // let dataSlice = this.data.avalanches.slice(0, 5);
-    // let testSvg = d3.select("#test").data(dataSlice);
+    let ttDiv = div
+      .append("div")
+      .attr("id", "tooltip")
+      .style("width", `${this.dimensions.tooltip.width}px`)
+      .style("height", `${this.dimensions.tooltip.height}px`)
+      .style("left", `${this.positions.tooltip.x}px`)
+      .style("top", `${this.positions.tooltip.y}px`);
+    // .style("position", "absolute");
 
-    // let tool = testSvg
-    //   .append("polygon")
-    //   .attr("id", (d, i) => `tooltip${i}`)
-    //   .attr("height", 600)
-    //   .attr("width", 600)
-    //   .attr(
-    //     "points",
-    //     "318.5 10, 701.5 10, 1010 318.5, 1010 701.5, 701.5 1010, 318.5 1010, 10 701.5, 10 318.5"
-    //   )
-    //   .style("fill", "lightgrey")
-    //   .style("stroke", "black")
-    //   .style("strokeWidth", "10px")
-    //   .style("opacity", 0)
-    //   .style("position", "absolute");
+    this.timeselect.render(tsDiv);
+    this.tooltip.render(ttDiv);
+    this.map.render(mapDiv);
 
-    // testSvg
-    //   .append("circle")
-    //   .attr("x", (d, i) => 100 * i)
-    //   .attr("y", (d, i) => 100 * i)
-    //   .attr("r", 50)
-    //   .attr("fill", "red")
-    //   .on("mouseover", function (e, d) {
-    //     tool.transition().duration(200).style("opacity", 0.9);
-    //     tool
-    //       .html(
-    //         "Attribute  Value   Plot" +
-    //           "<br/>" +
-    //           "Region: " +
-    //           d.Region +
-    //           "" +
-    //           "<br/>" +
-    //           "Place: " +
-    //           d.Place +
-    //           "" +
-    //           "<br/>" +
-    //           "Trigger: " +
-    //           d.Trigger +
-    //           "" +
-    //           "<br/>" +
-    //           "Width: " +
-    //           d.Width +
-    //           "" +
-    //           "<br/>" +
-    //           "Vertical: " +
-    //           d.Vertical +
-    //           "" +
-    //           "<br/>" +
-    //           "Aspect: " +
-    //           d.Aspect +
-    //           "" +
-    //           "<br/>" +
-    //           "Elevation: " +
-    //           d.Elevation +
-    //           "" +
-    //           "<br/>"
-    //       )
-    //       .style("left", d3.select(this).attr("cx") + "px")
-    //       .style("top", d3.select(this).attr("cy") + "px");
-    //   })
-    //   .on("mouseout", function (d) {
-    //     tool.transition().duration(500).style("opacity", 0);
-    //   });
+    this.elementIds = ["timeselect", "map-container", "tooltip"];
+  }
+
+  hide() {
+    this.elementIds.forEach((id) => document.getElementById(id).remove());
   }
 }
 export { Page1 };

--- a/js/page1/tooltip.js
+++ b/js/page1/tooltip.js
@@ -1,23 +1,27 @@
 // tooltip component in P1
 
+import * as utils from "../shared/utils.js";
+
 var leaflet = await import("https://cdn.skypack.dev/leaflet");
 import("leaflet").catch((e) => {});
 
 if (L === undefined) L = leaflet;
 
 class ToolTip{
-  constructor(data, width = 600, height = 600){
-    this.width = width;
-    this.height = height;
-
+  constructor(data){
+    this.dimensions = {};
     this.data = data.avalanches;
+  }
 
-    
+  render(div) {
+    this.div = div;
+    this.dimensions = utils.getDimensions(div);
+
     this.drawbubble();
     this.drawTable();
   }
 
-  drawbubble(){
+  drawbubble() {
     this.data.forEach(function(d){d.Width =parseInt(d.Width)});
     let data = [...this.data];
     let widthData = data.map(function(d){return d.Width});
@@ -37,11 +41,11 @@ class ToolTip{
         .domain([0,100])
         .range([400, 0]);
       
-      let svg2 = d3.select('body')
+      let svg2 = this.div
         .append('svg')
-        .attr('width', this.width)
-        .attr('height', this.height)
-        .attr('id', 'tooltip');
+        .attr('width', this.dimensions.width)
+        .attr('height', this.dimensions.height)
+        .attr('id', 'tooltip-svg');
       // Show the main vertical line
       svg2
       .append("line")
@@ -80,7 +84,8 @@ class ToolTip{
       .enter()
       .append("circle")
       .attr("cx",100)
-      .attr("cy", function(d){return(y(d.Width))/10+500})
+      // .attr("cy", d=>(y(d.Width))/10+500)
+      .attr("cy", (d,i)=>i*5)
       .attr("r", 4)
       .style("fill", "white")
       .attr("stroke", "black")
@@ -95,7 +100,7 @@ class ToolTip{
       this.data = this.data.filter(function(d){d.Region = "Ogden";})
       
       let columns = ['Region', 'Place', 'Trigger', 'Depth', 'Width', 'Vertical', 'Aspect', 'Elevation'];
-        let table = d3.select('body').append('table');
+        let table = this.div.append('table');
     
         let thead = table.append('thead');
         let tbody = table.append('tbody');

--- a/js/page2/page2.js
+++ b/js/page2/page2.js
@@ -1,0 +1,13 @@
+import * as utils from "../shared/utils.js";
+
+class Page2 {
+  constructor(data) {
+    console.log("Init Page 2");
+    this.data = data;
+  }
+
+  render() {}
+
+  hide() {}
+}
+export { Page2 };

--- a/js/page3/page3.js
+++ b/js/page3/page3.js
@@ -1,0 +1,13 @@
+import * as utils from "../shared/utils.js";
+
+class Page3 {
+  constructor(data) {
+    console.log("Init Page 3");
+    this.data = data;
+  }
+
+  render() {}
+
+  hide() {}
+}
+export { Page3 };

--- a/js/shared/timeselect.js
+++ b/js/shared/timeselect.js
@@ -1,5 +1,7 @@
 // time selection component in P1 and P2
 
+import * as utils from "./utils.js";
+
 /**
  *  This class creates a time selection component
  */
@@ -10,18 +12,19 @@ class TimeSelect {
      * and a specified width and height. If no dimesions are specified, the default is (0,0)
      * for x,y and 500x500 for width and height.
      * 
-     * @param {int} x 
-     * @param {int} y 
      * @param {int} width 
      * @param {int} height 
      */
-    constructor(data, x = 0, y = 0, width = 1000, height = 100) {
-        this.dimensions = this.x = {
-            x: x,
-            y: y,
-            width: width,
-            height: height
-        };
+    constructor(data) {
+        // this.dimensions = dimensions;
+        // this.dimensions = this.x = {
+        //     x: x,
+        //     y: y,
+        //     width: width,
+        //     height: height
+        // };
+
+        this.dimensions = {}
 
         this.dates = {date1: null, date2: null};
 
@@ -61,7 +64,7 @@ class TimeSelect {
 
         this.data = this.data.sort((a, b) => a.date - b.date);
 
-        this.draw();
+        // this.draw();
 
         // TODO: initialize new Event "timeUpdate" (or something like that)
 
@@ -71,17 +74,23 @@ class TimeSelect {
 
 
     /**
-     * This method draws the time selection component on the page.
+     * This method draws the time selection component in the div specified
+     * 
+     * @param {d3.Selection} div 
      */
-    draw() {
+     render(div) {
+        console.log(div)
+        this.dimensions = utils.getDimensions(div)
+
         // let data = [...this.data];
         //Creating svg to hold the time selection component
-        let svg = d3.select('body')
+        let svg = div
             .append('svg')
             .attr('width', this.dimensions.width)
             .attr('height', this.dimensions.height)
-            .attr('x', this.dimensions.x)
-            .attr('y', this.dimensions.y)
+            // .attr('x', this.dimensions.x)
+            // .attr('x', "1000px")
+            // .attr('y', this.dimensions.y)
             .attr('id', 'timeselect');
 
         //Creating groups to hold sub components

--- a/js/shared/utils.js
+++ b/js/shared/utils.js
@@ -1,0 +1,11 @@
+// Shared utility functions
+
+/**
+ * 
+ * @param {d3.Selection} selection 
+ * @returns {DOMRect} 
+ */
+export function getDimensions(selection) {
+    return selection.node().getBoundingClientRect()
+}
+


### PR DESCRIPTION
In general, this reinforces the ownership of Pages over their components by making Pages in charge of dimensions and positioning. It's not perfect, but the goal is to, eventually, transition to a paradigm where components are fit into page-specific layouts rather than sitting on explicitly specified coordinates. 

Changes:
- Dimensions and positions of components specified by the owning Page object
- Components can *infer* their own dimensions with the `utils.js::getDimensions` function
- Other pages have been skeletoned out, each with their own "render" and "hide" functions (open to renaming)
- Basic navigation established

(I'll make sure the merge preserves newer component functionality!)